### PR TITLE
Correção para trazer os horários que estão com o status ativo

### DIFF
--- a/backend/src/main/java/br/edu/senac/repositories/EspacoRepository.java
+++ b/backend/src/main/java/br/edu/senac/repositories/EspacoRepository.java
@@ -15,34 +15,34 @@ import jakarta.transaction.Transactional;
 @Repository
 public interface EspacoRepository extends JpaRepository<Espaco, Long> {
 
-  public List<Espaco> findAllByAtividadeIdAndStatusTrueAndEspacoHorariosNotNull(String atividadeId);
+    public List<Espaco> findAllByAtividadeIdAndStatusTrueAndEspacoHorariosNotNull(String atividadeId);
 
-  @Query(nativeQuery = true, value = """
-        SELECT H.id, H.horario_inicial, H.horario_final
-        FROM horarios AS H
-        INNER JOIN espacos_horarios AS EH ON H.id = EH.horario_id
-        INNER JOIN espacos AS E ON EH.espaco_id = E.id
-        INNER JOIN atividades AS A ON E.atividade_id = A.id
-        WHERE A.id = :atividadeId AND E.id = :espacoId
-        AND NOT EXISTS (
-            SELECT 1
-            FROM agendamentos AS AG
-            WHERE AG.espaco_horario_id = EH.id AND AG.data_agendamento = :dataAgendamento AND AG.status_id != 3
-        ) AND ((:dataAgendamento = CURDATE() AND H.horario_inicial > CURTIME()) OR (:dataAgendamento >  CURDATE()))
-        ORDER BY H.horario_inicial
-      """)
-  public List<Object[]> findByDataAndAtividadeId(@Param("atividadeId") String atividadeId,
-      @Param("dataAgendamento") LocalDate dataAgendamento, @Param("espacoId") Long espacoId);
+    @Query(nativeQuery = true, value = """
+              SELECT H.id, H.horario_inicial, H.horario_final
+              FROM horarios AS H
+              INNER JOIN espacos_horarios AS EH ON H.id = EH.horario_id
+              INNER JOIN espacos AS E ON EH.espaco_id = E.id
+              INNER JOIN atividades AS A ON E.atividade_id = A.id
+              WHERE A.id = :atividadeId AND E.id = :espacoId AND H.status = 1
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM agendamentos AS AG
+                  WHERE AG.espaco_horario_id = EH.id AND AG.data_agendamento = :dataAgendamento AND AG.status_id != 3
+              ) AND ((:dataAgendamento = CURDATE() AND H.horario_inicial > CURTIME()) OR (:dataAgendamento >  CURDATE()))
+              ORDER BY H.horario_inicial
+            """)
+    public List<Object[]> findByDataAndAtividadeId(@Param("atividadeId") String atividadeId,
+            @Param("dataAgendamento") LocalDate dataAgendamento, @Param("espacoId") Long espacoId);
 
-  @Query(nativeQuery = true, value = "SELECT DISTINCT E.*, H.id AS horario_id, H.horario_inicial, H.horario_final, H.status AS status_horario FROM espacos E INNER JOIN espacos_horarios EH ON E.id = EH.espaco_id INNER JOIN horarios H ON EH.horario_id = H.id WHERE E.atividade_id = :atividadeId AND E.status = TRUE AND H.status = 1")
-  public List<Espaco> findAllByAtividadeIdAndStatusTrueAndEspacoHorariosNotNullAndEspacoStatusTrue(
-      @Param("atividadeId") String atividadeId);
+    @Query(nativeQuery = true, value = "SELECT DISTINCT E.*, H.id AS horario_id, H.horario_inicial, H.horario_final, H.status AS status_horario FROM espacos E INNER JOIN espacos_horarios EH ON E.id = EH.espaco_id INNER JOIN horarios H ON EH.horario_id = H.id WHERE E.atividade_id = :atividadeId AND E.status = TRUE AND H.status = 1")
+    public List<Espaco> findAllByAtividadeIdAndStatusTrueAndEspacoHorariosNotNullAndEspacoStatusTrue(
+            @Param("atividadeId") String atividadeId);
 
-  public Espaco findByAtividadeIdAndNome(String id, String nome);
+    public Espaco findByAtividadeIdAndNome(String id, String nome);
 
-  @Modifying
-  @Transactional
-  @Query(nativeQuery = true, value = "UPDATE espacos SET status = true WHERE id = :id")
-  public void alternarStatusEspacoTrue(@Param("id") Long id);
+    @Modifying
+    @Transactional
+    @Query(nativeQuery = true, value = "UPDATE espacos SET status = true WHERE id = :id")
+    public void alternarStatusEspacoTrue(@Param("id") Long id);
 
 }


### PR DESCRIPTION
## Descrição

Este Pull Request resolve um problema específico, assegurando que apenas os horários com status ativo sejam exibidos ao usuário, melhorando a precisão das informações apresentadas no sistema SysClub.

## Commits Incluídos

- **fix: correção para trazer os horários que estão com o status ativo**: Traz somente os horários da atividade em que tem o status como ativo.

## Problema Resolvido

Este PR resolve especificamente a questão de exibir somente horários de atividades que estão com o status ativo, garantindo que os usuários tenham acesso apenas a horários disponíveis e evitando confusões ou agendamentos errôneos.

## Solução

A correção foi implementada para filtrar e exibir somente os horários que atendem ao critério de status ativo, conforme demonstrado no commit incluído. Isso aumenta a eficiência operacional ao eliminar a visibilidade de horários inativos no processo de agendamento.

## Benefícios

- **Precisão de Informações**: Assegura que somente horários válidos sejam mostrados aos usuários.
- **Eficiência Operacional**: Reduz o risco de agendamentos errôneos.
- **Melhoria da Usabilidade**: Facilita o processo de seleção de horário pelos usuários, simplificando a interface de agendamento.
- **Confiança do Usuário**: Aumenta a confiança dos usuários no sistema, ao proporcionar uma experiência mais consistente e livre de erros.

## Comandos para Testes

Por favor, execute os testes unitários e de integração para verificar as correções e melhorias implementadas neste PR.
